### PR TITLE
[#20] Replace env_logger with log4rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["full"] }
 futures = { version = "0.3" }
 log = "0.4"
-env_logger = "0.11"
+log4rs = "1.4"
 
 [build-dependencies]
 prost-build = { version = "0.14" }

--- a/src/bin/holocrondb_client.rs
+++ b/src/bin/holocrondb_client.rs
@@ -20,7 +20,7 @@ fn print_basic_help() {
 #[tokio::main]
 async fn main() -> Result<(), SocketError> {
     env::set_var("RUST_LOG", "trace");
-    env_logger::init();
+    log4rs::init_file("log4rs.yml", Default::default()).unwrap();
     let prompt_prefix = ">> ";
     let mut input = String::new();
     let mut exit_loop = false;

--- a/src/bin/holocrondb_server.rs
+++ b/src/bin/holocrondb_server.rs
@@ -6,8 +6,8 @@ use std::env;
 
 #[tokio::main]
 async fn main() -> io::Result<()> {
-     env::set_var("RUST_LOG", "trace");
-    env_logger::init();
+    env::set_var("RUST_LOG", "trace");
+    log4rs::init_file("log4rs.yml", Default::default()).unwrap();
     trace!("Hello, server!");
     let server = HolocronDBServer::new("127.0.0.1:8080",
     "default");


### PR DESCRIPTION
This commit replaces env_logger with log4rs with a basic configuration file.