### PR TITLE
fix: resolve 3 P0 critical bugs

### DIFF
--- a/src/bin/construct_cache_client.rs
+++ b/src/bin/construct_cache_client.rs
@@ -99,6 +99,9 @@ async fn main() -> Result<(), SocketError> {
         io::stdin().read_line(&mut input)
             .expect("Failed to read line");
         let ip = input.trim();
+        if ip.is_empty() {
+            continue;
+        }
         let control_char = ip.chars().nth(0).unwrap();
         let mut skip_input = false;
         match control_char {
@@ -114,14 +117,14 @@ async fn main() -> Result<(), SocketError> {
                 match split.next() {
                     None => { 
                         eprintln!("Expected key!");
-                        break;
+                        continue;
                     },
                     Some(x) => { key = x; }
                 }
                 match split.next() {
                     None => {
                         eprintln!("Expected value!");
-                        break;
+                        continue;
                     },
                     Some(x) => { val = x; }
                 }
@@ -134,7 +137,7 @@ async fn main() -> Result<(), SocketError> {
                 match split.next() {
                     None => {
                         eprintln!("Expected backup ID!");
-                        break;
+                        continue;
                     }
                     Some(x) => {backup_id = x; }
                 }
@@ -147,7 +150,7 @@ async fn main() -> Result<(), SocketError> {
                 match split.next() {
                     None => {
                         eprintln!("Expected message to ping!");
-                        break;
+                        continue;
                     },
                     Some(x) => { ping_msg = x; }
                 }
@@ -160,7 +163,7 @@ async fn main() -> Result<(), SocketError> {
                 match split.next() {
                     None => {
                         eprintln!("Expected backup ID!");
-                        break;
+                        continue;
                     }
                     Some(x) => {backup_id = x; }
                 }
@@ -173,7 +176,7 @@ async fn main() -> Result<(), SocketError> {
                 match split.next() {
                     None => {
                         eprintln!("Expected key to read!");
-                        break;
+                        continue;
                     }
                     Some(x) => {read_key = x; }
                 }
@@ -187,14 +190,14 @@ async fn main() -> Result<(), SocketError> {
                 match split.next() {
                     None => { 
                         eprintln!("Expected key!");
-                        break;
+                        continue;
                     },
                     Some(x) => { key = x; }
                 }
                 match split.next() {
                     None => {
                         eprintln!("Expected value!");
-                        break;
+                        continue;
                     },
                     Some(x) => { val = x; }
                 }
@@ -207,7 +210,7 @@ async fn main() -> Result<(), SocketError> {
                 match split.next() {
                     None => {
                         eprintln!("Expected key to delete!");
-                        break;
+                        continue;
                     },
                     Some(x) => { key = x; }
                 }

--- a/src/key_value_store/filestore.rs
+++ b/src/key_value_store/filestore.rs
@@ -2,7 +2,7 @@ use super::errors;
 use super::key_value_store::KeyValueStore;
 
 
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::prelude::*;
 
 use crate::{
@@ -44,39 +44,24 @@ pub fn write_to_file(store: KeyValueStore, target_file: &str) -> Result<(), erro
 }
 
 pub fn read_from_file(src_file: &str) -> Result<KeyValueStore, errors::RWError> {
-    let mut file;
-    match File::open(src_file) {
-        Ok(f) => {
-            file = f;
+    let buf = match fs::read(src_file) {
+        Ok(b) => {
+            if b.is_empty() {
+                return Err(RWError {
+                    kind_: ErrorKind::FileReadError,
+                    context_: String::from("Empty file!"),
+                });
+            }
+            b
         }
         Err(e) => {
             return Err(RWError {
                 kind_: ErrorKind::FileOpenError,
                 context_: e.to_string(),
-            })
+            });
         }
     };
-    let mut buf = vec![0; 1024];
-    // n_bytes will override the default 1024 byte buffer size to allow us to
-    // properly read the protobuf file.
-    let n_bytes: usize;
-    match file.read(&mut buf) {
-        Ok(n_b) => {
-            if n_b == 0 {
-                return Err(RWError { kind_: {ErrorKind::FileReadError},
-                    context_: String::from("Empty file!") })
-            } else {
-                n_bytes = n_b;
-            }
-        }
-        Err(e) => {
-            return Err(RWError {
-                kind_: ErrorKind::FileReadError,
-                context_: e.to_string(),
-            })
-        }
-    };
-    match KeyValueStoreMsg::decode(&buf[..n_bytes]) {
+    match KeyValueStoreMsg::decode(buf.as_slice()) {
         Ok(msg) => Ok(KeyValueStore::from(msg)),
         Err(e) => Err(RWError {
             kind_: ErrorKind::DataDecodeError,

--- a/src/key_value_store/key_value_store.rs
+++ b/src/key_value_store/key_value_store.rs
@@ -118,43 +118,28 @@ impl KeyValueStore {
     }
 
     pub fn read_from_file(&mut self, src_file: &str) -> Result<(), RWError> {
-        let mut file;
-        match File::open(src_file) {
-            Ok(f) => {
-                file = f;
+        let buf = match std::fs::read(src_file) {
+            Ok(b) => {
+                if b.is_empty() {
+                    return Err(RWError {
+                        kind_: ErrorKind::FileReadError,
+                        context_: String::from("Empty file!"),
+                    });
+                }
+                b
             }
             Err(e) => {
                 return Err(RWError {
                     kind_: ErrorKind::FileOpenError,
                     context_: e.to_string(),
-                })
+                });
             }
         };
-        let mut buf = vec![0; 1024];
-        // n_bytes will override the default 1024 byte buffer size to allow us to
-        // properly read the protobuf file.
-        let n_bytes: usize;
-        match file.read(&mut buf) {
-            Ok(n_b) => {
-                if n_b == 0 {
-                    return Err(RWError { kind_: {ErrorKind::FileReadError},
-                        context_: String::from("Empty file!") })
-                } else {
-                    n_bytes = n_b;
-                }
-            }
-            Err(e) => {
-                return Err(RWError {
-                    kind_: ErrorKind::FileReadError,
-                    context_: e.to_string(),
-                })
-            }
-        };
-        match KeyValueStoreMsg::decode(&buf[..n_bytes]) {
+        match KeyValueStoreMsg::decode(buf.as_slice()) {
             Ok(msg) => {
                 self.data_ = msg;
                 Ok(())
-            },
+            }
             Err(e) => Err(RWError {
                 kind_: ErrorKind::DataDecodeError,
                 context_: e.to_string(),


### PR DESCRIPTION
Fixes three critical bugs found during codebase review:

## Changes

### 1. Fix 1024-byte buffer truncation in `read_from_file` (fixes #32)
Both `filestore::read_from_file` and `KeyValueStore::read_from_file` used a fixed 1024-byte buffer with a single `file.read()` call. Any protobuf-encoded store larger than 1024 bytes was silently truncated, causing data loss or decode errors on restore. Replaced with `std::fs::read()` to read the entire file.

### 2. Fix client REPL exiting on invalid input (fixes #33)
All `break` statements in the client input-parsing match arms have been changed to `continue`, so bad input (e.g., `c` without a key) shows an error message and re-prompts instead of exiting the REPL.

### 3. Fix client panic on empty input (fixes #34)
Added an `is_empty()` guard before accessing `ip.chars().nth(0).unwrap()` to prevent a panic when the user presses Enter with no input.

## Testing
- `cargo build` succeeds
- All 8 existing unit tests pass (`cargo test`)